### PR TITLE
プロトタイプ一覧表示機能の実装

### DIFF
--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,6 +1,6 @@
 class PrototypesController < ApplicationController
   def index
-    # @prototype = Prototype.new
+    @prototypes = Prototype.all
     # @prototypes = Prototype.includes(:user)
   end
 

--- a/app/views/prototypes/index.html.erb
+++ b/app/views/prototypes/index.html.erb
@@ -6,6 +6,7 @@
       </div>
     <div class="card__wrapper">
       <%# 投稿機能実装後、部分テンプレートでプロトタイプ投稿一覧を表示する %>
+      <%= render partial:'prototype',collection: @prototypes %>
       </div>
   </div>
 </main>

--- a/app/views/prototypes/index.html.erb
+++ b/app/views/prototypes/index.html.erb
@@ -5,7 +5,6 @@
         <%= link_to "#{current_user.name}さん", root_path, class: :greeting__link %>
       </div>
     <div class="card__wrapper">
-      <%# 投稿機能実装後、部分テンプレートでプロトタイプ投稿一覧を表示する %>
       <%= render partial:'prototype',collection: @prototypes %>
       </div>
   </div>


### PR DESCRIPTION
What
プロトタイプ一覧表示機能の実装
Why
プロトタイプ一覧表示機能の実装するため。

プロトタイプ情報が一覧で表示されている動画（新規投稿後に一覧表示に遷移する）
https://gyazo.com/6a76dd57910426cfeeffae49a938b180

ご確認よろしくお願いします。