### PR TITLE
個別ページへのリンクの修正

### DIFF
--- a/app/views/prototypes/_prototype.html.erb
+++ b/app/views/prototypes/_prototype.html.erb
@@ -1,10 +1,12 @@
 <div class="card">
     <%= image_tag prototype.image, class: 'prototype-image' if prototype.image.attached? %>
   <div class="card__body">
-    <%= link_to "プロトタイプのタイトル", root_path, class: :card__title%>
+    <%= link_to prototype.title, prototype_path(prototype), class: :card__title%>
     <p class="card__summary">
-      <%= "プロトタイプのキャッチコピー" %>
+      <%= prototype.catch_copy %>
     </p>
-    <%= link_to  "by #{@prototype.user.name}", root_path, class: :card__user %>
+    <% if prototype.user %>
+    <%= link_to prototype.user.name, prototype_path(prototype), class: :card__user %>
+    <% end %>
   </div>
 </div>


### PR DESCRIPTION
what
プロトタイプ一覧表示機能の実装の修正。
why
プロトタイプ一覧表示機能の実施、挙動確認。

プロトタイプ投稿後、一覧が表示される。
プロトタイプ毎に画像、プロトタイプ名、キャッチコピー、投稿者名が表示される。
https://gyazo.com/555fe9f1394fa31955f3664710ba44e2