### PR TITLE
コメント投稿機能

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,2 @@
+class CommentsController < ApplicationController
+end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -5,6 +5,7 @@ class CommentsController < ApplicationController
   end
 
   private
+
   def comment_params
     params.require(:comment).permit(:content).merge(user_id: current_user.id, prototype_id: params[:prototype_id])
   end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,2 +1,11 @@
 class CommentsController < ApplicationController
+  def create
+    comment = Comment.create(comment_params)
+    redirect_to "/prototypes/#{comment.prototype.id}"
+  end
+
+  private
+  def comment_params
+    params.require(:comment).permit(:content).merge(user_id: current_user.id, prototype_id: params[:prototype_id])
+  end
 end

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -21,6 +21,8 @@ class PrototypesController < ApplicationController
   end
 
   def show
+    @comment = Comment.new
+    @comments = @prototype.comments.includes(:user)
   end
 
   private

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -1,0 +1,2 @@
+module CommentsHelper
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,2 @@
+class Comment < ApplicationRecord
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,2 +1,4 @@
 class Comment < ApplicationRecord
+  belongs_to :prototype
+  belongs_to :user
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,4 +1,5 @@
 class Comment < ApplicationRecord
   belongs_to :prototype
   belongs_to :user
+  validates :content, presence: true
 end

--- a/app/models/prototype.rb
+++ b/app/models/prototype.rb
@@ -1,6 +1,6 @@
 class Prototype < ApplicationRecord
   belongs_to :user
-  has_many :comments
+  has_many :comments, dependent: :destroy
   has_one_attached :image
   validates :title, presence: true
   validates :catch_copy, presence: true

--- a/app/models/prototype.rb
+++ b/app/models/prototype.rb
@@ -1,5 +1,6 @@
 class Prototype < ApplicationRecord
   belongs_to :user
+  has_many :comments
   has_one_attached :image
   validates :title, presence: true
   validates :catch_copy, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,4 +8,5 @@ class User < ApplicationRecord
   validates :occupation, presence: true
   validates :position, presence: true
   has_many :prototypes
+  has_many :comments
 end

--- a/app/views/prototypes/_prototype.html.erb
+++ b/app/views/prototypes/_prototype.html.erb
@@ -1,10 +1,10 @@
 <div class="card">
     <%= image_tag prototype.image, class: 'prototype-image' if prototype.image.attached? %>
   <div class="card__body">
-    <%= link_to "プロトタイプのタイトル", root_path, class: :card__title%>
+    <%= link_to prototype.title, prototype_path(prototype), class: :card__title%>
     <p class="card__summary">
-      <%= "プロトタイプのキャッチコピー" %>
+      <%= prototype.catch_copy %>
     </p>
-    <%= link_to  "by #{@prototype.user.name}", root_path, class: :card__user %>
+    <%= link_to  prototype.user.name, root_path, class: :card__user %>
   </div>
 </div>

--- a/app/views/prototypes/index.html.erb
+++ b/app/views/prototypes/index.html.erb
@@ -7,7 +7,9 @@
       </div>
       <% end %>
     <div class="card__wrapper">
-      <%= render partial:'prototype',collection: @prototypes %>
+    
+       <%= render partial: 'prototype' ,collection: @prototypes %>
+    
       </div>
   </div>
 </main>

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -29,7 +29,6 @@
         </div>
       </div>
       <div class="prototype__comments">
-        <%# ログインしているユーザーには以下のコメント投稿フォームを表示する %>
          <% if user_signed_in? %>
           <%= form_with model: [@prototype, @comment],local: true do |f| %>
             <div class="field">
@@ -42,16 +41,13 @@
             </div>
           <% end %>
          <% end %>
-        <%# // ログインしているユーザーには上記を表示する %>
         <ul class="comments_lists">
-          <%# 投稿に紐づくコメントを一覧する処理を記述する %>
            <% @comments.each do |comment| %>
             <li class="comments_list">
               <%= comment.content %>
               <%= link_to comment.user.name, root_path, class: :comment_user %>
             </li>
            <% end %>
-          <%# // 投稿に紐づくコメントを一覧する処理を記述する %>
         </ul>
       </div>
     </div>

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -28,27 +28,32 @@
           </p>
         </div>
       </div>
-      <%# <div class="prototype__comments">
+      <div class="prototype__comments">
         <%# ログインしているユーザーには以下のコメント投稿フォームを表示する %>
-          <%# <%= form_with model: モデル名,local: true do |f|%>
-            <%# <div class="field"> %>
-              <%# <%= f.label :hoge, "コメント"<br /> %>
-              <%# <%= f.text_field :hoge, id:"comment_content" %>
-            <%# </div> %>
-            <%# <div class="actions"> %>
-              <%# <%= f.submit "送信する", class: :form__btn  %>
-            <%# </div> %>
-          <%# <% end %>
+         <% if user_signed_in?>
+          <%= form_with model: [@prototype, @comment],local: true do |f| %>
+            <div class="field">
+              <%= f.label :hoge, "コメント" %>
+              <br />
+              <%= f.text_field :hoge, id:"comment_content" %>
+            </div>
+            <div class="actions">
+              <%= f.submit "送信する", class: :form__btn %>
+            </div>
+          <% end %>
+         <% end %>
         <%# // ログインしているユーザーには上記を表示する %>
-        <%# <ul class="comments_lists"> %>
+        <ul class="comments_lists">
           <%# 投稿に紐づくコメントを一覧する処理を記述する %>
-            <%# <li class="comments_list"> %>
-              <%# <%= " コメントのテキスト "%>
-              <%# <%= link_to "（ ユーザー名 ）", root_path, class: :comment_user %>
-            <%# </li> %>
+           <% @comments.each do |comment| %>
+            <li class="comments_list">
+              <%= " コメントのテキスト " %>
+              <%= link_to comment.user.name, root_path, class: :comment_user %>
+            </li>
+           <% end %>
           <%# // 投稿に紐づくコメントを一覧する処理を記述する %>
-        <%# </ul> %>
-      <%# </div> %>
+        </ul>
+      </div>
     </div>
   </div>
 </main>

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -30,12 +30,12 @@
       </div>
       <div class="prototype__comments">
         <%# ログインしているユーザーには以下のコメント投稿フォームを表示する %>
-         <% if user_signed_in?>
+         <% if user_signed_in? %>
           <%= form_with model: [@prototype, @comment],local: true do |f| %>
             <div class="field">
-              <%= f.label :hoge, "コメント" %>
+              <%= f.label :content, "コメント" %>
               <br />
-              <%= f.text_field :hoge, id:"comment_content" %>
+              <%= f.text_field :content, id:"comment_content" %>
             </div>
             <div class="actions">
               <%= f.submit "送信する", class: :form__btn %>
@@ -47,7 +47,7 @@
           <%# 投稿に紐づくコメントを一覧する処理を記述する %>
            <% @comments.each do |comment| %>
             <li class="comments_list">
-              <%= " コメントのテキスト " %>
+              <%= comment.content %>
               <%= link_to comment.user.name, root_path, class: :comment_user %>
             </li>
            <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   get 'prototypes/index'
   root to: "prototypes#index"
-  resources :prototypes, only: [:index, :new, :create, :show]
+  resources :prototypes, only: [:index, :new, :create, :show] do
+    resources :comments, only: [:create]
+  end
 end

--- a/db/migrate/20240129185224_create_comments.rb
+++ b/db/migrate/20240129185224_create_comments.rb
@@ -1,0 +1,10 @@
+class CreateComments < ActiveRecord::Migration[7.0]
+  def change
+    create_table :comments do |t|
+      t.text :content
+      t.integer :prototype_id
+      t.integer :user_id
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_27_230518) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_29_185224) do
   create_table "active_storage_attachments", charset: "utf8", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -37,6 +37,14 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_27_230518) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "comments", charset: "utf8", force: :cascade do |t|
+    t.text "content"
+    t.integer "prototype_id"
+    t.integer "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "prototypes", charset: "utf8", force: :cascade do |t|

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CommentsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 class CommentsControllerTest < ActionDispatch::IntegrationTest
   # test "the truth" do

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 class CommentTest < ActiveSupport::TestCase
   # test "the truth" do

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CommentTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
#what
コメント投稿機能
#why
コメント投稿機能を追加したため

プロトタイプ情報を削除すると、紐づいたコメントも削除されることについてはプロトタイプ情報削除機能を追加した後確認

- 必要な情報を適切に入力して「送信する」ボタンを押すと、投稿したコメントとその投稿者名が対象プロトタイプの詳細ページに表示される動画。
https://gyazo.com/807097e347d68f1583e6629226c0c215

- ログアウト状態で、プロトタイプ詳細ページに遷移し、コメント投稿フォームが表示されない動画。
https://gyazo.com/b8731618da508bcd2c780333f91f4423

- フォームを空のまま投稿しようとすると、投稿できずにそのページに留まること。
https://gyazo.com/e1df7160bafe14e4c813ea19a5613898